### PR TITLE
Support for fPIC and overridable RV_PREFIX

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 # Libraries available are compiled with riscv32-unknown-elf-
 
 XLEN ?=			32
-RV_PREFIX = 	riscv${XLEN}-unknown-elf-
+RV_PREFIX ?= 	riscv${XLEN}-unknown-elf-
 CC = 			$(RV_PREFIX)gcc
 AR = 			$(RV_PREFIX)ar
 OBJDUMP = 		$(RV_PREFIX)objdump
@@ -18,6 +18,7 @@ F_EXTENSION		?= N
 ARCH = rv${XLEN}i
 
 DEBUG 			?= Y
+FPIC			?= N
 
 ifeq ($(M_EXTENSION), Y)
 ARCH := $(addsuffix m,$(ARCH))
@@ -50,6 +51,10 @@ CFLAGS += 		-c
 
 ifeq ($(DEBUG), Y)
 CFLAGS +=		-g
+endif
+
+ifeq ($(FPIC), Y)
+CFLAGS +=		-fPIC
 endif
 
 # Include

--- a/README.md
+++ b/README.md
@@ -63,9 +63,15 @@ To compile without debug symbols and `muldiv` extension:
 make DEBUG=N M_EXTENSION=N
 
 ```
-As a sidenote, TinyIO supports both 32 and 64 bits architecture. Default is 32, but to build at 64 bits
+
+TinyIO supports both 32 and 64 bits architecture. Default is 32, but to build at 64 bits
 ```
 make XLEN=64
+```
+
+Additionally, the default toolchain can be overridden and the `-fPIC` flag can be enabled with:
+```
+make RV_PREFIX=<alternative-toolchain> FPIC=Y
 ```
 
 # Contribution


### PR DESCRIPTION
- Update Makefile 
- Update README with toolchain and -fPIC flag details

